### PR TITLE
Add Go v1.18 to test matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,10 +13,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.16', '1.17']
+        go: ['1.17', '1.18']
     steps:
       - name: setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{matrix.go}}
 
@@ -26,10 +26,10 @@ jobs:
           terraform_wrapper: false
 
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: tools
-        run: GO111MODULE=off go get golang.org/x/lint/golint
+        run: go install golang.org/x/lint/golint@latest
 
       - name: test
         run: make


### PR DESCRIPTION
* Update Github Actions `setup-go` and `checkout`
* Change `go get <tool>` to `go install <tool>`
* Remove Go v1.16