### PR TITLE
Rename register `set` field to `content`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@ Notable changes between releases.
 
 ## Latest
 
+## v0.2.1
+
+* Rename `util_register` field from `set` to `content`
+* Fix `util_register` to mark `value` attribute as computed to propagate changes
+
 ## v0.2.0
 
 * Add `util_register` resource for storing values

--- a/README.md
+++ b/README.md
@@ -36,19 +36,19 @@ output "example" {
 }
 ```
 
-Store a value in state that persists until changed to a non-empty value.
+Store a content value that persists in state until changed to a non-empty value.
 
 ```tf
 resource "util_register" "example" {
-  set = "a1b2c3"
+  content = "a1b2c3"
 }
 ```
 
-Later, the register's value may be updated, but setting it to `null` or `""` is ignored.
+Later, the register's content may be updated, but empty values (`null` or `""`) are ignored.
 
 ```tf
 resource "util_register" "example" {
-  set = null
+  content = null
 }
 
 output "sha" {

--- a/docs/resources/register.md
+++ b/docs/resources/register.md
@@ -1,18 +1,18 @@
 # Register
 
-Store a value in state that persists until changed to a non-empty value.
+Store a content value that persists in state until changed to a non-empty value.
 
 ```tf
 resource "util_register" "example" {
-  set = "a1b2c3"
+  content = "a1b2c3"
 }
 ```
 
-Later, the register's value may be updated, but setting it to `null` or `""` is ignored.
+Later, the register's content may be updated, but empty values (`null` or `""`) are ignored.
 
 ```tf
 resource "util_register" "example" {
-  set = null
+  content = null
 }
 
 output "sha" {
@@ -22,8 +22,8 @@ output "sha" {
 
 ## Argument Reference
 
-* `set` - set the register value (`""` or `null` values ignored)
+* `content` - set the register value (`""` or `null` values ignored)
 
 ## Attribute Reference
 
-* `value` - computed value of the register
+* `value` - computed register value

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,3 +1,3 @@
 resource "util_register" "example" {
-  set = "a1b2c3"
+  content = "a1b2c3"
 }

--- a/util/resource_register.go
+++ b/util/resource_register.go
@@ -17,7 +17,7 @@ func resourceRegister() *schema.Resource {
 		UpdateContext: registerUpdate,
 		DeleteContext: registerDelete,
 		Schema: map[string]*schema.Schema{
-			"set": &schema.Schema{
+			"content": &schema.Schema{
 				Type: schema.TypeString,
 				// Allow content to be null
 				Optional: true,
@@ -36,9 +36,9 @@ func resourceRegister() *schema.Resource {
 				Description: "Computed register value",
 			},
 		},
-		// Changes to set (that are non-empty) mark value as computed
+		// Changes to content (that are non-empty) mark value as computed
 		CustomizeDiff: customdiff.ComputedIf("value", func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool {
-			return d.HasChange("set") && d.Get("set").(string) != ""
+			return d.HasChange("content") && d.Get("content").(string) != ""
 		}),
 	}
 }
@@ -46,9 +46,9 @@ func resourceRegister() *schema.Resource {
 // registerCreate stores content as the register value.
 func resourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
-	set := d.Get("set").(string)
-	d.Set("value", set)
-	d.SetId(strconv.Itoa(hashcode.String(set)))
+	content := d.Get("content").(string)
+	d.Set("value", content)
+	d.SetId(strconv.Itoa(hashcode.String(content)))
 	return diags
 }
 
@@ -62,9 +62,9 @@ func registerRead(ctx context.Context, d *schema.ResourceData, meta interface{})
 func registerUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	set := d.Get("set").(string)
-	if set != "" {
-		d.Set("value", set)
+	content := d.Get("content").(string)
+	if content != "" {
+		d.Set("value", content)
 	}
 	return diags
 }

--- a/util/resource_register_test.go
+++ b/util/resource_register_test.go
@@ -8,7 +8,7 @@ import (
 
 const registerInitial = `
 resource "util_register" "example" {
-	set = "a1b2c3"
+	content = "a1b2c3"
 }
 
 output "out" {
@@ -18,7 +18,7 @@ output "out" {
 
 const registerUnsetSHA = `
 resource "util_register" "example" {
-	set = ""
+	content = ""
 }
 
 output "out" {
@@ -28,7 +28,7 @@ output "out" {
 
 const registerUpdateSHA = `
 resource "util_register" "example" {
-	set = "b2c3d4"
+	content = "b2c3d4"
 }
 
 output "out" {


### PR DESCRIPTION
* The noun `content` is a better field name than the verb `set`