### PR TITLE
Improve util_register plan diff to show expected value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,14 +4,18 @@ Notable changes between releases.
 
 ## Latest
 
+## v0.2.2
+
+* Improve `util_register` plan diff to show expected value
+
 ## v0.2.1
 
-* Rename `util_register` field from `set` to `content`
-* Fix `util_register` to mark `value` attribute as computed to propagate changes
+* Rename `util_register` field from `set` to `content` ([#9](https://github.com/poseidon/terraform-provider-util/pull/9))
+* Fix `util_register` to mark `value` attribute as computed to propagate changes ([#8](https://github.com/poseidon/terraform-provider-util/pull/8))
 
 ## v0.2.0
 
-* Add `util_register` resource for storing values
+* Add `util_register` resource for storing values ([#7](https://github.com/poseidon/terraform-provider-util/pull/7))
 
 ## v0.1.0
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/util"
-      version = "0.2.0"
+      version = "0.2.2"
     }
   }
 }

--- a/util/datasource_replace.go
+++ b/util/datasource_replace.go
@@ -19,16 +19,16 @@ func datasourceReplace() *schema.Resource {
 		ReadContext: datasourceReplaceRead,
 
 		Schema: map[string]*schema.Schema{
-			"content": &schema.Schema{
+			"content": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"replacements": &schema.Schema{
+			"replacements": {
 				Type:     schema.TypeMap,
 				Elem:     schema.TypeString,
 				Required: true,
 			},
-			"replaced": &schema.Schema{
+			"replaced": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "content with replacements performed",

--- a/util/datasource_replace_test.go
+++ b/util/datasource_replace_test.go
@@ -33,13 +33,13 @@ func TestReplace(t *testing.T) {
 	r.UnitTest(t, r.TestCase{
 		Providers: testProviders,
 		Steps: []r.TestStep{
-			r.TestStep{
+			{
 				Config: replaceExample1,
 				Check: r.ComposeTestCheckFunc(
 					r.TestCheckResourceAttr("data.util_replace.example", "replaced", replaceExpected1),
 				),
 			},
-			r.TestStep{
+			{
 				Config: replaceExample2,
 				Check: r.ComposeTestCheckFunc(
 					r.TestCheckResourceAttr("data.util_replace.example", "replaced", replaceExpected2),

--- a/util/resource_register_test.go
+++ b/util/resource_register_test.go
@@ -47,7 +47,7 @@ func TestRegister(t *testing.T) {
 		Providers: testProviders,
 		Steps: []r.TestStep{
 			// set initial value
-			r.TestStep{
+			{
 				Config: registerInitial,
 				Check: r.ComposeTestCheckFunc(
 					r.TestCheckResourceAttr("util_register.example", "value", registerInitialExpected),
@@ -55,7 +55,7 @@ func TestRegister(t *testing.T) {
 				),
 			},
 			// Empty content does NOT change value
-			r.TestStep{
+			{
 				Config: registerUnsetSHA,
 				Check: r.ComposeTestCheckFunc(
 					r.TestCheckResourceAttr("util_register.example", "value", registerInitialExpected),
@@ -63,7 +63,7 @@ func TestRegister(t *testing.T) {
 				),
 			},
 			// Non-empty content DOES change value
-			r.TestStep{
+			{
 				Config: registerUpdateSHA,
 				Check: r.ComposeTestCheckFunc(
 					r.TestCheckResourceAttr("util_register.example", "value", registerUpdateExpected),
@@ -71,7 +71,7 @@ func TestRegister(t *testing.T) {
 				),
 			},
 			// suppress noisy diffs that won't affect value
-			r.TestStep{
+			{
 				Config:   registerUnsetSHA,
 				PlanOnly: true,
 				Check: r.ComposeTestCheckFunc(


### PR DESCRIPTION
* In CustomizedDiff, instead of just marking `value` as computed (known at apply), set it to its new known value. Terraform plans will show the expected content value after apply
* As before, changing content to "" or null has no affect