### PR TITLE
Fix golangci-lint warnings

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,11 +1,6 @@
 name: test
 on:
   push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
 jobs:
   build:
     name: go
@@ -27,9 +22,6 @@ jobs:
 
       - name: checkout
         uses: actions/checkout@v3
-
-      - name: tools
-        run: go install golang.org/x/lint/golint@latest
 
       - name: test
         run: make

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ Notable changes between releases.
 
 ## v0.2.2
 
-* Improve `util_register` plan diff to show expected value
+* Improve `util_register` plan diff to show expected value ([#10](https://github.com/poseidon/terraform-provider-util/pull/10))
 
 ## v0.2.1
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
 export CGO_ENABLED:=0
-export GO111MODULE=on
 
 VERSION=$(shell git describe --tags --match=v* --always --dirty)
 SEMVER=$(shell git describe --tags --match=v* --always --dirty | cut -c 2-)
 
 .PHONY: all
-all: build test vet lint fmt
+all: build test vet fmt
 
 .PHONY: build
 build: clean bin/terraform-provider-util
@@ -20,10 +19,6 @@ test:
 .PHONY: vet
 vet:
 	@go vet -all ./...
-
-.PHONY: lint
-lint:
-	@golint -set_exit_status `go list ./...`
 
 .PHONY: fmt
 fmt:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ $ terraform init
 
 ### Binary
 
-To develop the provider plugin locally, build an executable with Go v1.16+.
+To develop the provider plugin locally, build an executable with Go v1.17+.
 
 ```
 make

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,53 @@
 module github.com/poseidon/terraform-provider-util
 
-go 1.16
+go 1.17
+
+require github.com/hashicorp/terraform-plugin-sdk/v2 v2.20.0
 
 require (
-	github.com/hashicorp/terraform-plugin-sdk/v2 v2.20.0
-	google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d // indirect
+	github.com/agext/levenshtein v1.2.2 // indirect
+	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fatih/color v1.13.0 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.8 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 // indirect
+	github.com/hashicorp/go-hclog v1.2.1 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/go-plugin v1.4.4 // indirect
+	github.com/hashicorp/go-uuid v1.0.3 // indirect
+	github.com/hashicorp/go-version v1.6.0 // indirect
+	github.com/hashicorp/hc-install v0.4.0 // indirect
+	github.com/hashicorp/hcl/v2 v2.13.0 // indirect
+	github.com/hashicorp/logutils v1.0.0 // indirect
+	github.com/hashicorp/terraform-exec v0.17.2 // indirect
+	github.com/hashicorp/terraform-json v0.14.0 // indirect
+	github.com/hashicorp/terraform-plugin-go v0.12.0 // indirect
+	github.com/hashicorp/terraform-plugin-log v0.7.0 // indirect
+	github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c // indirect
+	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 // indirect
+	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/oklog/run v1.0.0 // indirect
+	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
+	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
+	github.com/vmihailenco/tagparser v0.1.1 // indirect
+	github.com/zclconf/go-cty v1.10.0 // indirect
+	golang.org/x/crypto v0.0.0-20220517005047-85d78b3ac167 // indirect
+	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
+	golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 // indirect
+	golang.org/x/text v0.3.7 // indirect
+	google.golang.org/appengine v1.6.6 // indirect
+	google.golang.org/genproto v0.0.0-20200711021454-869866162049 // indirect
+	google.golang.org/grpc v1.48.0 // indirect
+	google.golang.org/protobuf v1.28.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -321,9 +321,8 @@ google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoA
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
+google.golang.org/genproto v0.0.0-20200711021454-869866162049 h1:YFTFpQhgvrLrmxtiIncJxFXeCyq84ixuKWVCaCAi9Oc=
 google.golang.org/genproto v0.0.0-20200711021454-869866162049/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d h1:92D1fum1bJLKSdr11OJ+54YeCMCGYIygTA7R/YZxH5M=
-google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=

--- a/util/datasource_replace.go
+++ b/util/datasource_replace.go
@@ -43,7 +43,9 @@ func datasourceReplaceRead(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.FromErr(err)
 	}
 
-	d.Set("replaced", replaced)
+	if err := d.Set("replaced", replaced); err != nil {
+		return diag.FromErr(err)
+	}
 	d.SetId(Hashcode(replaced))
 	return diags
 }

--- a/util/resource_register.go
+++ b/util/resource_register.go
@@ -36,7 +36,9 @@ func resourceRegister() *schema.Resource {
 		// Changes to content (that are non-empty) mark value as computed
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
 			if content := d.Get("content").(string); d.HasChange("content") && content != "" {
-				d.SetNew("value", content)
+				if err := d.SetNew("value", content); err != nil {
+					return err
+				}
 			}
 			return nil
 		},
@@ -47,7 +49,9 @@ func resourceRegister() *schema.Resource {
 func resourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	content := d.Get("content").(string)
-	d.Set("value", content)
+	if err := d.Set("value", content); err != nil {
+		return diag.FromErr(err)
+	}
 	d.SetId(Hashcode(content))
 	return diags
 }
@@ -64,7 +68,9 @@ func registerUpdate(ctx context.Context, d *schema.ResourceData, meta interface{
 
 	content := d.Get("content").(string)
 	if content != "" {
-		d.Set("value", content)
+		if err := d.Set("value", content); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 	return diags
 }


### PR DESCRIPTION
* Update minimum expected Go version to v1.17
* Remove deprecated golint tooling