### PR TITLE
Add NixOS Module import block parser and awkball serializer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 export CGO_ENABLED:=0
 
-VERSION=$(shell git describe --tags --match=v* --always --dirty)
-SEMVER=$(shell git describe --tags --match=v* --always --dirty | cut -c 2-)
+VERSION=$(shell git describe --tags --match=v* --always)
+SEMVER=$(shell git describe --tags --match=v* --always | cut -c 2-)
 
 .PHONY: all
 all: build test vet fmt
@@ -40,10 +40,13 @@ release: \
 
 _output/plugin-%.zip: NAME=terraform-provider-util_$(SEMVER)_$(subst -,_,$*)
 _output/plugin-%.zip: DEST=_output/$(NAME)
+_output/plugin-%.zip: LOCAL=$(HOME)/.terraform.d/plugins/terraform.localhost/poseidon/util/$(SEMVER)
 _output/plugin-%.zip: _output/%/terraform-provider-util
 	@mkdir -p $(DEST)
 	@cp _output/$*/terraform-provider-util $(DEST)/terraform-provider-util_$(VERSION)
 	@zip -j $(DEST).zip $(DEST)/terraform-provider-util_$(VERSION)
+	mkdir -p $(LOCAL)/$(subst -,_,$*)
+	cp _output/$*/terraform-provider-util $(LOCAL)/$(subst -,_,$*)/terraform-provider-util_$(VERSION)
 
 _output/linux-amd64/terraform-provider-util: GOARGS = GOOS=linux GOARCH=amd64
 _output/linux-arm64/terraform-provider-util: GOARGS = GOOS=linux GOARCH=arm64

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,17 @@ go 1.21
 
 toolchain go1.21.5
 
-require github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0
+require (
+	github.com/hashicorp/terraform-plugin-sdk/v2 v2.34.0
+	github.com/stretchr/testify v1.7.2
+)
 
 require (
 	github.com/ProtonMail/go-crypto v1.1.0-alpha.2 // indirect
 	github.com/agext/levenshtein v1.2.2 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
@@ -41,6 +45,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/oklog/run v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
@@ -55,4 +60,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240227224415-6ceb2ff114de // indirect
 	google.golang.org/grpc v1.63.2 // indirect
 	google.golang.org/protobuf v1.34.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/collect.go
+++ b/internal/collect.go
@@ -1,0 +1,44 @@
+package internal
+
+import (
+	"io/fs"
+	"path/filepath"
+)
+
+// CollectModules parses NixOS module import blocks recursively.
+func CollectModules(filesystem fs.FS, path string) ([]*NixOSModule, error) {
+	modules := []*NixOSModule{}
+	stack := []string{path}
+
+	for len(stack) > 0 {
+		path = stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+
+		// fs.FS does not have a direct os implementation that allows rooted
+		// paths (e.g. /home/user/...). afero was better at this.
+		// https://github.com/golang/go/issues/47803
+		data, err := fs.ReadFile(filesystem, path)
+		if err != nil {
+			return nil, err
+		}
+
+		// parse NixOS module imports
+		module, err := ParseContent(string(data))
+		if err != nil {
+			return nil, err
+		}
+		module.Path = path
+
+		modules = append(modules, module)
+
+		// traverse in-tree imported NixOS modules
+		for _, nmi := range module.Imports {
+			if !nmi.inTree {
+				continue
+			}
+			resolvedPath := filepath.Join(filepath.Dir(path), nmi.path)
+			stack = append(stack, resolvedPath)
+		}
+	}
+	return modules, nil
+}

--- a/internal/collect_test.go
+++ b/internal/collect_test.go
@@ -1,0 +1,33 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCollectModules(t *testing.T) {
+	testFS := setupTestFilesystem()
+	cases := []struct {
+		path    string
+		modules []*NixOSModule
+	}{
+		{
+			path:    moduleA.Path,
+			modules: []*NixOSModule{moduleA, moduleB, moduleC},
+		},
+		{
+			path:    moduleB.Path,
+			modules: []*NixOSModule{moduleB, moduleC},
+		},
+		{
+			path:    moduleC.Path,
+			modules: []*NixOSModule{moduleC},
+		},
+	}
+	for _, c := range cases {
+		modules, err := CollectModules(testFS, c.path)
+		assert.Nil(t, err)
+		assert.Equal(t, c.modules, modules)
+	}
+}

--- a/internal/encode.go
+++ b/internal/encode.go
@@ -1,0 +1,71 @@
+package internal
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+var awkballPrefix = "modules"
+
+// Encode encodes the NixOS modules in awkball format, with each file
+// separated by a `#### path` marker. An awkball can be decoded to
+// files using an awk one-liner.
+//
+//	#### configuration.nix
+//	content
+//	#### modules/a.nix
+//	content
+//
+// The first module is considered the entrypoint and assigned the given
+// entrypoint filename. Others are organized under modules. Imports are
+// modified to match.
+func EncodeToAwkball(entrypoint string, modules []*NixOSModule) string {
+	var sb strings.Builder
+	for i, module := range modules {
+		var name string
+		var content string
+		if i == 0 {
+			name = entrypoint
+			content = module.RewriteImports(awkballPrefix)
+		} else {
+			name = filepath.Join(awkballPrefix, filepath.Base(module.Path))
+			content = module.RewriteImports("")
+		}
+		sb.WriteString(fmt.Sprintf("#### %s\n%s", name, content))
+	}
+	return sb.String()
+}
+
+// NixOSModule represents info from a NixOS module.
+type NixOSModule struct {
+	Path    string
+	Content string
+	Imports []*NixOSModuleImport
+}
+
+type NixOSModuleImport struct {
+	path   string
+	inTree bool
+}
+
+// Rewrite imports returns the NixOS module content with imports rewritten
+// for a remote system.
+func (m *NixOSModule) RewriteImports(prefix string) string {
+	imports := []string{}
+	// evaluate all nixos module imports
+	for _, nmi := range m.Imports {
+		// source/intree NixOS module
+		if nmi.inTree {
+			rewrite := fmt.Sprintf("./%s", filepath.Join(prefix, filepath.Base(nmi.path)))
+			imports = append(imports, rewrite)
+		} else {
+			imports = append(imports, nmi.path)
+		}
+	}
+
+	return moduleImportsRegexp.ReplaceAllString(
+		m.Content,
+		fmt.Sprintf("imports = [ %s ];", strings.Trim(strings.Join(imports, " "), " ")),
+	)
+}

--- a/internal/encode_test.go
+++ b/internal/encode_test.go
@@ -1,0 +1,87 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var awkballABC = `#### configuration.nix
+{ modulesPath, lib, pkgs, ...}:
+{
+  system.stateVersion = "24.05";
+  imports = [ "${toString modulesPath}/nixpkgs" ./modules/server.nix ];
+}
+#### modules/server.nix
+{ lib, pkgs, ...}:
+{
+  imports = [ ./feature.nix ];
+  services.openssh = {
+    enable = true;
+  };
+}
+#### modules/feature.nix
+{ pkgs }:
+let
+  x = 1;
+{
+  inherit x;
+  options = {};
+  config = {};
+}
+`
+
+var awkballBC = `#### configuration.nix
+{ lib, pkgs, ...}:
+{
+  imports = [ ./modules/feature.nix ];
+  services.openssh = {
+    enable = true;
+  };
+}
+#### modules/feature.nix
+{ pkgs }:
+let
+  x = 1;
+{
+  inherit x;
+  options = {};
+  config = {};
+}
+`
+
+var awkballC = `#### configuration.nix
+{ pkgs }:
+let
+  x = 1;
+{
+  inherit x;
+  options = {};
+  config = {};
+}
+`
+
+func TestEncode(t *testing.T) {
+	cases := []struct {
+		modules  []*NixOSModule
+		expected string
+	}{
+		{
+			[]*NixOSModule{moduleA, moduleB, moduleC},
+			awkballABC,
+		},
+		{
+			[]*NixOSModule{moduleB, moduleC},
+			awkballBC,
+		},
+		{
+			[]*NixOSModule{moduleC},
+			awkballC,
+		},
+	}
+
+	for _, c := range cases {
+		awkball := EncodeToAwkball("configuration.nix", c.modules)
+		assert.Equal(t, c.expected, awkball)
+	}
+}

--- a/internal/fs.go
+++ b/internal/fs.go
@@ -1,0 +1,74 @@
+package internal
+
+import (
+	"io/fs"
+	"os"
+	"strings"
+	"time"
+)
+
+type osFS struct {
+	// filename -> content
+	overlay map[string]string
+}
+
+func NewOSFS() fs.FS {
+	return &osFS{}
+}
+
+func NewOverlayFS(overlay map[string]string) fs.FS {
+	return &osFS{
+		overlay: overlay,
+	}
+}
+
+func (f *osFS) Open(name string) (fs.File, error) {
+	if content, present := f.overlay[name]; present {
+		return NewStringFile(content), nil
+	}
+
+	data, err := os.ReadFile(name)
+	if err != nil {
+		return nil, err
+	}
+	return NewStringFile(string(data)), err
+}
+
+type StringFile struct {
+	data *strings.Reader
+}
+
+func NewStringFile(content string) *StringFile {
+	return &StringFile{
+		data: strings.NewReader(content),
+	}
+}
+
+// Read implements the io.Reader interface
+func (f *StringFile) Read(p []byte) (int, error) {
+	return f.data.Read(p)
+}
+
+// Stat implements the fs.File interface
+func (f *StringFile) Stat() (fs.FileInfo, error) {
+	return &fileInfo{
+		size: int64(f.data.Len()),
+	}, nil
+}
+
+// Close implements the fs.File interface
+func (f *StringFile) Close() error {
+	return nil
+}
+
+// fileInfo implements fs.FileInfo
+type fileInfo struct {
+	size int64
+}
+
+func (fi *fileInfo) Name() string       { return "string file" }
+func (fi *fileInfo) Size() int64        { return fi.size }
+func (fi *fileInfo) Mode() fs.FileMode  { return 0 }
+func (fi *fileInfo) ModTime() time.Time { return time.Time{} }
+func (fi *fileInfo) IsDir() bool        { return false }
+func (fi *fileInfo) Sys() interface{}   { return nil }

--- a/internal/parse.go
+++ b/internal/parse.go
@@ -1,0 +1,52 @@
+package internal
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Regular expression to match NixOS module's imports blocks.
+//
+//	  imports = [
+//		   capture group, [^\]] matches any character except ]
+//	  ]
+var moduleImportsRegexp = regexp.MustCompile(`imports[\s]*=[\s]*\[[\s]*(?<imports>[^\]]*)[\s]*\];`)
+
+// ParseContent parses NixOS Module imports.
+func ParseContent(content string) (*NixOSModule, error) {
+	// all captured imports
+	imports := []*NixOSModuleImport{}
+
+	// find earliest match, only one imports block discovered for now
+	matches := moduleImportsRegexp.FindStringSubmatch(content)
+	if len(matches) > 1 {
+		// capture group captures raw contents (e.g. imports = [ contents ];)
+		capture := matches[1]
+		// TODO: It would be nice to be able to use fields, but some imports have
+		// spaces in them
+		//fields := strings.Fields(capture)
+		fields := strings.Split(capture, "\n")
+
+		for _, field := range fields {
+			line := strings.TrimSpace(field)
+			// most imports are "in-tree" file references to be traversed. Exceptions:
+			// - interpolations are assumed to resolve at runtime
+			if line != "" && !strings.HasPrefix(line, "#") && !strings.Contains(line, "$") {
+				imports = append(imports, &NixOSModuleImport{
+					path:   line,
+					inTree: true,
+				})
+			} else if line != "" && !strings.HasPrefix(line, "#") {
+				// preserve non-comment imports as-is. Comments are removed.
+				imports = append(imports, &NixOSModuleImport{
+					path: line,
+				})
+			}
+		}
+	}
+
+	return &NixOSModule{
+		Content: content,
+		Imports: imports,
+	}, nil
+}

--- a/internal/parse_test.go
+++ b/internal/parse_test.go
@@ -1,0 +1,22 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseModule(t *testing.T) {
+	cases := []*NixOSModule{
+		moduleA,
+		moduleB,
+		moduleC,
+	}
+
+	for _, c := range cases {
+		module, err := ParseContent(c.Content)
+		assert.Nil(t, err)
+		assert.Equal(t, c.Imports, module.Imports)
+		assert.Equal(t, c.Content, module.Content)
+	}
+}

--- a/internal/test_test.go
+++ b/internal/test_test.go
@@ -1,0 +1,80 @@
+package internal
+
+import (
+	"io/fs"
+	"testing/fstest"
+)
+
+var (
+	moduleA = &NixOSModule{
+		Path: "infra/nix/machines/configuration.nix",
+		Content: `{ modulesPath, lib, pkgs, ...}:
+{
+  system.stateVersion = "24.05";
+  imports = [
+    "${toString modulesPath}/nixpkgs"
+    ../modules/server.nix
+		# ../modules/other.nix
+  ];
+}
+`,
+		Imports: []*NixOSModuleImport{
+			{
+				path:   "\"${toString modulesPath}/nixpkgs\"",
+				inTree: false,
+			},
+			{
+				path:   "../modules/server.nix",
+				inTree: true,
+			},
+		},
+	}
+
+	moduleB = &NixOSModule{
+		Path: "infra/nix/modules/server.nix",
+		Content: `{ lib, pkgs, ...}:
+{
+  imports = [
+    ./feature.nix
+  ];
+  services.openssh = {
+    enable = true;
+  };
+}
+`,
+		Imports: []*NixOSModuleImport{
+			{
+				path:   "./feature.nix",
+				inTree: true,
+			},
+		},
+	}
+
+	moduleC = &NixOSModule{
+		Path: "infra/nix/modules/feature.nix",
+		Content: `{ pkgs }:
+let
+  x = 1;
+{
+  inherit x;
+  options = {};
+  config = {};
+}
+`,
+		Imports: []*NixOSModuleImport{},
+	}
+)
+
+func setupTestFilesystem() fs.FS {
+	return fstest.MapFS{
+		moduleA.Path: &fstest.MapFile{
+			Data: []byte(moduleA.Content),
+		},
+		moduleB.Path: &fstest.MapFile{
+			Data: []byte(moduleB.Content),
+		},
+		moduleC.Path: &fstest.MapFile{
+			Data: []byte(moduleC.Content),
+		},
+	}
+}

--- a/util/datasource_nix.go
+++ b/util/datasource_nix.go
@@ -1,0 +1,70 @@
+package util
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/poseidon/terraform-provider-util/internal"
+)
+
+func datasourceNix() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceNixRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"path": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"overlay": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     schema.TypeString,
+			},
+			"rendered": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "render merged modules",
+			},
+		},
+	}
+}
+
+func datasourceNixRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	rendered, err := renderContent(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("rendered", rendered); err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(Hashcode(rendered))
+	return diags
+}
+
+func renderContent(d *schema.ResourceData) (string, error) {
+	// unchecked assertions seem to be the norm in Terraform :S
+	name := d.Get("name").(string)
+	path := d.Get("path").(string)
+	overlays := map[string]string{}
+	for k, v := range d.Get("overlay").(map[string]interface{}) {
+		overlays[k] = v.(string)
+	}
+	path = filepath.Clean(path)
+
+	fsys := internal.NewOverlayFS(overlays)
+	modules, err := internal.CollectModules(fsys, path)
+	if err != nil {
+		return "", err
+	}
+	return internal.EncodeToAwkball(name, modules), nil
+}

--- a/util/datasource_nix_test.go
+++ b/util/datasource_nix_test.go
@@ -1,0 +1,75 @@
+package util
+
+import (
+	"testing"
+
+	r "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const nixExample1 = `
+data "util_nix" "example" {
+	name = "configuration.nix"
+	path = "./testdata/foo.nix"
+}
+`
+
+const nixExpected1 = `#### configuration.nix
+{ modulesPath, lib, pkgs, ...}:
+{
+  system.stateVersion = "24.05";
+  imports = [ "${toString modulesPath}/nixpkgs" ./modules/bar.nix ];
+}
+#### modules/bar.nix
+{
+  imports = [ ./baz.nix ];
+
+  options = {};
+  config = {};
+}
+#### modules/baz.nix
+{ pkgs }:
+let
+  x = 1;
+{
+  inherit x;
+}
+`
+
+const nixExample2 = `
+data "util_nix" "example" {
+	name = "configuration.nix"
+	path = "./testdata/foo.nix"
+	overlay = {
+		"testdata/foo.nix" = <<-EOT
+{ modulesPath, lib, pkgs, ...}:
+{
+  system.stateVersion = "24.05";
+  imports = [
+    "$${toString modulesPath}/nixpkgs"
+    ./bar.nix
+  ];
+}
+EOT
+	}
+}
+`
+
+func TestNix(t *testing.T) {
+	r.UnitTest(t, r.TestCase{
+		Providers: testProviders,
+		Steps: []r.TestStep{
+			{
+				Config: nixExample1,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("data.util_nix.example", "rendered", nixExpected1),
+				),
+			},
+			{
+				Config: nixExample2,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("data.util_nix.example", "rendered", nixExpected1),
+				),
+			},
+		},
+	})
+}

--- a/util/provider.go
+++ b/util/provider.go
@@ -12,6 +12,7 @@ func Provider() *schema.Provider {
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"util_replace": datasourceReplace(),
+			"util_nix":     datasourceNix(),
 		},
 	}
 }

--- a/util/testdata/bar.nix
+++ b/util/testdata/bar.nix
@@ -1,0 +1,8 @@
+{
+  imports = [
+    ./baz.nix
+  ];
+
+  options = {};
+  config = {};
+}

--- a/util/testdata/baz.nix
+++ b/util/testdata/baz.nix
@@ -1,0 +1,6 @@
+{ pkgs }:
+let
+  x = 1;
+{
+  inherit x;
+}

--- a/util/testdata/foo.nix
+++ b/util/testdata/foo.nix
@@ -1,0 +1,8 @@
+{ modulesPath, lib, pkgs, ...}:
+{
+  system.stateVersion = "24.05";
+  imports = [
+    "${toString modulesPath}/nixpkgs"
+    ./bar.nix
+  ];
+}


### PR DESCRIPTION
* Parse NixOS Module imports blocks recursively to collect the set of in-tree modules. Serialize them into an awkball for some experimental use cases