### PR TITLE
Prepare to release v0.3.0

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,12 @@
+changelog:
+  categories:
+    - title: Contributions
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - dependencies
+          - no-release-note
+    - title: Dependencies
+      labels:
+        - dependencies

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@ Notable changes between releases.
 
 ## Latest
 
+## v0.3.0
+
+* Add `util_nix` to parse and serialize NixOS modules as awkballs
+  * Note, this is highly unusual utility I required. It's quite experimental
+
 ## v0.2.2
 
 * Improve `util_register` plan diff to show expected value ([#10](https://github.com/poseidon/terraform-provider-util/pull/10))

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,8 @@ _output/%/terraform-provider-util:
 
 release-sign:
 	cd _output; sha256sum *.zip > terraform-provider-util_$(SEMVER)_SHA256SUMS
-	gpg2 --detach-sign _output/terraform-provider-util_$(SEMVER)_SHA256SUMS
+	gpg --default-key 0x8F515AD1602065C8 --detach-sign _output/terraform-provider-util_$(SEMVER)_SHA256SUMS
 
 release-verify: NAME=_output/terraform-provider-util
 release-verify:
-	gpg2 --verify $(NAME)_$(SEMVER)_SHA256SUMS.sig $(NAME)_$(SEMVER)_SHA256SUMS
+	gpg --default-key 0x8F515AD1602065C8 --verify $(NAME)_$(SEMVER)_SHA256SUMS.sig $(NAME)_$(SEMVER)_SHA256SUMS

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/util"
-      version = "0.2.2"
+      version = "0.3.0"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/util"
-      version = "0.2.0"
+      version = "0.3.0"
     }
   }
 }


### PR DESCRIPTION
* Bump version in README and docs
* Update release signing process to specify the legacy RSA key since Hashicorp does not support ed25519 keys
* Add release.yaml to generate release notes