### PR TITLE
Add util_jwks data source to convert public keys to JWKS documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ provider "util" {}
 
 terraform {
   required_providers {
-    ct = {
+    util = {
       source  = "poseidon/util"
-      version = "0.3.0"
+      version = "0.4.0"
     }
   }
 }
@@ -38,6 +38,18 @@ data "util_replace" "example" {
 # Hallo Welt
 output "example" {
   value = data.ct_replace.example.replaced
+}
+```
+
+Convert a Kubernetes Service Account public key into a JWKS document for OIDC discovery.
+
+```hcl
+data "util_jwks" "cluster" {
+  public_key = module.cluster.service_account_public_key
+}
+
+output "jwks" {
+  value = data.util_jwks.cluster.jwks
 }
 ```
 

--- a/docs/data-sources/jwks.md
+++ b/docs/data-sources/jwks.md
@@ -1,0 +1,40 @@
+# jwks Data Source
+
+`jwks` converts a PEM-encoded RSA or ECDSA public key into a JSON Web Key Set (JWKS) document. The output matches Kubernetes service account issuer discovery defaults, so it can be used when serving `/openid/v1/jwks` from static OIDC discovery metadata.
+
+## Usage
+
+```hcl
+data "util_jwks" "cluster" {
+  public_key = module.cluster.service_account_public_key
+}
+
+module "oidc-discovery" {
+  source       = "some/module/for/oidc-discovery"
+  cluster_name = "cluster"
+  jwks         = data.util_jwks.cluster.jwks
+}
+```
+
+## Kubernetes Compatibility
+
+Kubernetes derives the `kid` for service account signing keys by marshaling the public key as DER SubjectPublicKeyInfo, hashing those bytes with SHA-256, and base64url-encoding the digest without padding.
+
+This is intentionally different from hashing the PEM text, hashing only the RSA modulus, using a certificate thumbprint, or using an RFC 7638 JWK thumbprint. Matching Kubernetes is important because service account JWT headers and JWKS entries must use the same `kid`.
+
+RSA keys are published with `alg = "RS256"`. ECDSA keys use the same curve mapping as Kubernetes: P-256 uses `ES256`, P-384 uses `ES384`, and P-521 uses `ES512`.
+
+See upstream Kubernetes:
+
+* [`keyIDFromPublicKey`](https://github.com/kubernetes/kubernetes/blob/v1.36.1/pkg/serviceaccount/jwt.go#L90-L110)
+* [`StaticPublicKeysGetter`](https://github.com/kubernetes/kubernetes/blob/v1.36.1/pkg/serviceaccount/jwt.go#L273-L291)
+* [`openIDKeysetJSON`](https://github.com/kubernetes/kubernetes/blob/v1.36.1/pkg/serviceaccount/openidmetadata.go#L237-L252)
+* [`jwkFromPublicKey`](https://github.com/kubernetes/kubernetes/blob/v1.36.1/pkg/serviceaccount/openidmetadata.go#L291-L313)
+
+## Argument Reference
+
+* `public_key` - PEM-encoded RSA or ECDSA public key
+
+## Argument Attributes
+
+* `jwks` - Kubernetes-compatible JSON Web Key Set for the public key

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,9 +11,9 @@ provider "util" {}
 
 terraform {
   required_providers {
-    ct = {
+    util = {
       source  = "poseidon/util"
-      version = "0.3.0"
+      version = "0.4.0"
     }
   }
 }

--- a/internal/datasource_jwks.go
+++ b/internal/datasource_jwks.go
@@ -1,0 +1,226 @@
+package internal
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func datasourceJWKS() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceJWKSRead,
+
+		Schema: map[string]*schema.Schema{
+			"public_key": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "PEM-encoded RSA or ECDSA public key",
+			},
+			"jwks": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Kubernetes-compatible JSON Web Key Set for the public key",
+			},
+		},
+	}
+}
+
+func datasourceJWKSRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	jwks, err := jwksFromPublicKeyPEM(d.Get("public_key").(string))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("jwks", jwks); err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(Hashcode(jwks))
+	return diags
+}
+
+type jwksDocument struct {
+	Keys []jwk `json:"keys"`
+}
+
+type jwk struct {
+	Use       string `json:"use"`
+	KeyType   string `json:"kty"`
+	KeyID     string `json:"kid"`
+	Curve     string `json:"crv,omitempty"`
+	Algorithm string `json:"alg"`
+	Modulus   string `json:"n,omitempty"`
+	Exponent  string `json:"e,omitempty"`
+	X         string `json:"x,omitempty"`
+	Y         string `json:"y,omitempty"`
+}
+
+// jwksFromPublicKeyPEM converts one PEM-encoded public key into a JWKS document
+// compatible with Kubernetes service account issuer discovery.
+func jwksFromPublicKeyPEM(content string) (string, error) {
+	publicKey, err := parsePublicKeyPEM(content)
+	if err != nil {
+		return "", err
+	}
+
+	key, err := publicKeyToJWK(publicKey)
+	if err != nil {
+		return "", err
+	}
+	jwks := jwksDocument{
+		Keys: []jwk{key},
+	}
+
+	data, err := json.Marshal(jwks)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal JWKS: %w", err)
+	}
+	return string(data), nil
+}
+
+// parsePublicKeyPEM decodes PEM-formatted content containing a PKIX public key
+// or a PKCS1 RSA public key.
+func parsePublicKeyPEM(content string) (crypto.PublicKey, error) {
+	block, _ := pem.Decode([]byte(content))
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode PEM public key")
+	}
+
+	switch block.Type {
+	case "PUBLIC KEY":
+		publicKey, err := x509.ParsePKIXPublicKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse PKIX public key: %w", err)
+		}
+		return publicKey, nil
+	case "RSA PUBLIC KEY":
+		publicKey, err := x509.ParsePKCS1PublicKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse PKCS1 RSA public key: %w", err)
+		}
+		return publicKey, nil
+	default:
+		return nil, fmt.Errorf("unsupported PEM block type %q: expected PUBLIC KEY or RSA PUBLIC KEY", block.Type)
+	}
+}
+
+// publicKeyToJWK converts supported public keys to the same public JWK shape
+// Kubernetes publishes from /openid/v1/jwks.
+func publicKeyToJWK(publicKey crypto.PublicKey) (jwk, error) {
+	switch publicKey := publicKey.(type) {
+	case *rsa.PublicKey:
+		return rsaPublicKeyToJWK(publicKey)
+	case *ecdsa.PublicKey:
+		return ecdsaPublicKeyToJWK(publicKey)
+	default:
+		return jwk{}, fmt.Errorf("unsupported public key type %T: only RSA and ECDSA public keys are supported", publicKey)
+	}
+}
+
+func rsaPublicKeyToJWK(publicKey *rsa.PublicKey) (jwk, error) {
+	keyID, err := kubernetesKeyIDFromPublicKey(publicKey)
+	if err != nil {
+		return jwk{}, err
+	}
+
+	return jwk{
+		Use:       "sig",
+		KeyType:   "RSA",
+		KeyID:     keyID,
+		Algorithm: "RS256",
+		Modulus:   base64.RawURLEncoding.EncodeToString(publicKey.N.Bytes()),
+		Exponent:  base64.RawURLEncoding.EncodeToString(big.NewInt(int64(publicKey.E)).Bytes()),
+	}, nil
+}
+
+func ecdsaPublicKeyToJWK(publicKey *ecdsa.PublicKey) (jwk, error) {
+	keyID, err := kubernetesKeyIDFromPublicKey(publicKey)
+	if err != nil {
+		return jwk{}, err
+	}
+
+	var curve, algorithm string
+	switch publicKey.Curve {
+	case elliptic.P256():
+		curve = "P-256"
+		algorithm = "ES256"
+	case elliptic.P384():
+		curve = "P-384"
+		algorithm = "ES384"
+	case elliptic.P521():
+		curve = "P-521"
+		algorithm = "ES512"
+	default:
+		return jwk{}, fmt.Errorf("unknown ECDSA public key curve: must be P-256, P-384, or P-521")
+	}
+
+	size := (publicKey.Curve.Params().BitSize + 7) / 8
+	return jwk{
+		Use:       "sig",
+		KeyType:   "EC",
+		KeyID:     keyID,
+		Curve:     curve,
+		Algorithm: algorithm,
+		X:         base64.RawURLEncoding.EncodeToString(fixedLengthBytes(publicKey.X, size)),
+		Y:         base64.RawURLEncoding.EncodeToString(fixedLengthBytes(publicKey.Y, size)),
+	}, nil
+}
+
+func fixedLengthBytes(value *big.Int, size int) []byte {
+	data := value.Bytes()
+	if len(data) >= size {
+		return data
+	}
+
+	padded := make([]byte, size)
+	copy(padded[size-len(data):], data)
+	return padded
+}
+
+// kubernetesKeyIDFromPublicKey derives a Kubernetes-compatible service account
+// key ID (`kid`) from a public key.
+func kubernetesKeyIDFromPublicKey(publicKey crypto.PublicKey) (string, error) {
+	// This must match kube-apiserver's service account token implementation.
+	// Kubernetes puts the same Key ID (`kid`) in JWT headers and in the JWKS
+	// entry served from /openid/v1/jwks, so relying parties can choose the
+	// right verification key.
+	//
+	// There are several plausible but incompatible ways to identify a key:
+	// hashing the PEM text, hashing only the RSA modulus, using a certificate
+	// thumbprint, or using the RFC 7638 JWK thumbprint. Kubernetes does none
+	// of those for its built-in service account signer. Instead, it marshals
+	// the public key as DER SubjectPublicKeyInfo with x509.MarshalPKIXPublicKey,
+	// hashes those bytes with SHA-256, then base64url-encodes the digest without
+	// padding.
+	//
+	// Keep this aligned with upstream Kubernetes defaults:
+	// https://github.com/kubernetes/kubernetes/blob/v1.36.1/pkg/serviceaccount/jwt.go#L90-L110
+	//   keyIDFromPublicKey derives the kid from DER SubjectPublicKeyInfo.
+	// https://github.com/kubernetes/kubernetes/blob/v1.36.1/pkg/serviceaccount/jwt.go#L273-L291
+	//   StaticPublicKeysGetter attaches that kid to each public key.
+	// https://github.com/kubernetes/kubernetes/blob/v1.36.1/pkg/serviceaccount/openidmetadata.go#L237-L252
+	//   openIDKeysetJSON renders the JWKS document.
+	// https://github.com/kubernetes/kubernetes/blob/v1.36.1/pkg/serviceaccount/openidmetadata.go#L291-L313
+	//   jwkFromPublicKey preserves the kid and adds use=sig and the matching
+	//   signing algorithm for RSA or ECDSA keys.
+	publicKeyDERBytes, err := x509.MarshalPKIXPublicKey(publicKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to serialize public key to DER format: %w", err)
+	}
+
+	hash := sha256.Sum256(publicKeyDERBytes)
+	return base64.RawURLEncoding.EncodeToString(hash[:]), nil
+}

--- a/internal/datasource_jwks_test.go
+++ b/internal/datasource_jwks_test.go
@@ -1,0 +1,118 @@
+package internal
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"strings"
+	"testing"
+
+	r "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const jwksPublicKey = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyutR5sZOMK+JwDafWm4i
+5ncsyed9IwlY+bmsBwg89fYfggr/aO5Xno30njifscTDdbK2y0uon3OPXPjARipI
+t6duEzlesdwKcBImBkyxe/I3GzS0ARpJtzpRMV+8mceNRbr3ce++SClEd/SvBWrR
+/RJ1w862R86iwsS3k6LJbPTe+efT3ppyeAiLG/9ds7bQGwdRMT6Zr882eJl66ZwN
+t5iZ8GebI8A1MLKSaJsCHFP8jRhKtjeme5/IcWGdwbaEKye5DXcgKHjCcewwHco2
+pcmj4PQyBO/PI547oPlfSYQrcdN8VFiMBFxIscicLXbEH2GfQKj5cJ7/nbsC+gAh
+wQIDAQAB
+-----END PUBLIC KEY-----`
+
+const jwksECDSAPublicKey = `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEH6cuzP8XuD5wal6wf9M6xDljTOPL
+X2i8uIp/C/ASqiIGUeeKQtX0/IR3qCXyThP/dbCiHrF3v1cuhBOHY8CLVg==
+-----END PUBLIC KEY-----`
+
+const jwksExample = `
+data "util_jwks" "example" {
+  public_key = <<-EOT
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyutR5sZOMK+JwDafWm4i
+5ncsyed9IwlY+bmsBwg89fYfggr/aO5Xno30njifscTDdbK2y0uon3OPXPjARipI
+t6duEzlesdwKcBImBkyxe/I3GzS0ARpJtzpRMV+8mceNRbr3ce++SClEd/SvBWrR
+/RJ1w862R86iwsS3k6LJbPTe+efT3ppyeAiLG/9ds7bQGwdRMT6Zr882eJl66ZwN
+t5iZ8GebI8A1MLKSaJsCHFP8jRhKtjeme5/IcWGdwbaEKye5DXcgKHjCcewwHco2
+pcmj4PQyBO/PI547oPlfSYQrcdN8VFiMBFxIscicLXbEH2GfQKj5cJ7/nbsC+gAh
+wQIDAQAB
+-----END PUBLIC KEY-----
+EOT
+}
+`
+
+const jwksExpected = `{"keys":[{"use":"sig","kty":"RSA","kid":"HvfxvoDusbEuKLtBer21gBVQO2m09IlZO_gcBCAhf0M","alg":"RS256","n":"yutR5sZOMK-JwDafWm4i5ncsyed9IwlY-bmsBwg89fYfggr_aO5Xno30njifscTDdbK2y0uon3OPXPjARipIt6duEzlesdwKcBImBkyxe_I3GzS0ARpJtzpRMV-8mceNRbr3ce--SClEd_SvBWrR_RJ1w862R86iwsS3k6LJbPTe-efT3ppyeAiLG_9ds7bQGwdRMT6Zr882eJl66ZwNt5iZ8GebI8A1MLKSaJsCHFP8jRhKtjeme5_IcWGdwbaEKye5DXcgKHjCcewwHco2pcmj4PQyBO_PI547oPlfSYQrcdN8VFiMBFxIscicLXbEH2GfQKj5cJ7_nbsC-gAhwQ","e":"AQAB"}]}`
+
+const jwksECDSAExpected = `{"keys":[{"use":"sig","kty":"EC","kid":"SoABiieYuNx4UdqYvZRVeuC6SihxgLrhLy9peHMHpTc","crv":"P-256","alg":"ES256","x":"H6cuzP8XuD5wal6wf9M6xDljTOPLX2i8uIp_C_ASqiI","y":"BlHnikLV9PyEd6gl8k4T_3Wwoh6xd79XLoQTh2PAi1Y"}]}`
+
+func TestJWKS_RSAPublicKey(t *testing.T) {
+	r.UnitTest(t, r.TestCase{
+		Providers: testProviders,
+		Steps: []r.TestStep{
+			{
+				Config: jwksExample,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("data.util_jwks.example", "jwks", jwksExpected),
+				),
+			},
+		},
+	})
+
+	got, err := jwksFromPublicKeyPEM(jwksPublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != jwksExpected {
+		t.Fatalf("got %q, want %q", got, jwksExpected)
+	}
+}
+
+func TestJWKS_ECDSAPublicKey(t *testing.T) {
+	got, err := jwksFromPublicKeyPEM(jwksECDSAPublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != jwksECDSAExpected {
+		t.Fatalf("got %q, want %q", got, jwksECDSAExpected)
+	}
+}
+
+func TestJWKSInvalidPEM(t *testing.T) {
+	_, err := jwksFromPublicKeyPEM("not a PEM public key")
+	if err == nil || !strings.Contains(err.Error(), "failed to decode PEM public key") {
+		t.Fatalf("got error %v, want failed PEM decode error", err)
+	}
+}
+
+func TestJWKSWrongPEMBlockType(t *testing.T) {
+	content := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: []byte("not a public key"),
+	})
+
+	_, err := jwksFromPublicKeyPEM(string(content))
+	if err == nil || !strings.Contains(err.Error(), `unsupported PEM block type "CERTIFICATE"`) {
+		t.Fatalf("got error %v, want unsupported PEM block type error", err)
+	}
+}
+
+func TestJWKSUnsupportedPublicKey(t *testing.T) {
+	publicKey, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	publicKeyDER, err := x509.MarshalPKIXPublicKey(publicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := pem.EncodeToMemory(&pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: publicKeyDER,
+	})
+
+	_, err = jwksFromPublicKeyPEM(string(content))
+	if err == nil || !strings.Contains(err.Error(), "only RSA and ECDSA public keys are supported") {
+		t.Fatalf("got error %v, want unsupported public key type error", err)
+	}
+}

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -11,6 +11,7 @@ func Provider() *schema.Provider {
 			"util_register": resourceRegister(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"util_jwks":    datasourceJWKS(),
 			"util_replace": datasourceReplace(),
 			"util_nix":     datasourceNix(),
 		},


### PR DESCRIPTION
* Use the jwks utility to convert a PEM-encoded RSA/ECDSA public key (such as the public key used by Kubernetes Service Accounts and output from Typhoon) to a JSON Web Key Set that can be served via OIDC discovery documents
* Replaces the need to run `kubectl get --raw "/openid/v1/jwks" | jq .` after a cluster is created. The jwks keys to publish can be known immediately